### PR TITLE
Adding a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Security Vulnerabilities
+
+If you discover a security vulnerability within Laravel, please send an e-mail to our technical team via [technical@php-fusion.co.uk](mailto:technical@php-fusion.co.uk). All security vulnerabilities will be promptly addressed.


### PR DESCRIPTION
I recommned that PHP-Fusion adds this policy for now so that all the vulnerability reports that are being reported publicly on Github are moved to be private disclosures to protect PHP-Fusion and all the people that use the software. If down the road PHP-Fusion makes a new infusion for the main site to report vulnerabilities then this policy can be updated to direct people there.