### PR TITLE
Update CoreTables.php

### DIFF
--- a/includes/classes/PHPFusion/Installer/Lib/CoreTables.php
+++ b/includes/classes/PHPFusion/Installer/Lib/CoreTables.php
@@ -1116,7 +1116,7 @@ class CoreTables {
             ], //submit_id MEDIUMINT(8) UNSIGNED NOT NULL AUTO_INCREMENT,
             'submit_type'      => [
                 'type'   => 'CHAR',
-                'length' => 1,
+                'length' => 4,
             ],// submit_type CHAR(1) NOT NULL,
             'submit_user'      => [
                 'type'     => 'BIGINT',


### PR DESCRIPTION
The length is also 4 in the admin table, so it is better separated, there will never be the same type.

If possible, it should be 4 lengths by default