### PR TITLE
Properly escape attributes in Social Media links.

### DIFF
--- a/includes/theme_functions_include.php
+++ b/includes/theme_functions_include.php
@@ -1845,10 +1845,10 @@ if (!function_exists('social_media_links')) {
         if (!empty($services) && is_array($services)) {
             foreach ($services as $service) {
                 $html .= strtr($options["template"], [
-                    "{%class%}" => $options["class"],
-                    "{%url%}"   => $service["url"].$url,
-                    "{%name%}"  => $service["name"],
-                    "{%icon%}"  => $service["icon"]
+                    "{%class%}" => esc_attr( $options["class"] ),
+                    "{%url%}"   => esc_url( $service["url"] . urlencode($url) ),
+                    "{%name%}"  => esc_attr( $service["name"] ),
+                    "{%icon%}"  => esc_attr( $service["icon"] )
                 ]);
             }
         }


### PR DESCRIPTION
Properly escape attributes in Social Media links.

Sometimes a shared url has GET parameters, while the main url of the social media platform also uses GET parameters. The social media service then gets confused and posts the wrong url.

Bug was introduced by me :)
I am not involved anymore with the website that uses PHPFusion, and I am not that familiar anymore with the codebase and the different versions. I did think it would be proper to come back on this.
Please test as you see fit.

Regards, Marcel